### PR TITLE
Reformat repositories

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 Jan Raasch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Hugo static site based on https://github.com/zjedi/hugo-scroll

--- a/content/homepage/repositories.md
+++ b/content/homepage/repositories.md
@@ -31,11 +31,6 @@ Serves as a central hub for Bible NLP resources.
 **Baseline experiments run on the ebible dataset**  
 Provides a starting point for researchers working with the ebible corpus.
 
-### [biblical_names 🔗](https://github.com/BibleNLP/biblical_names)
-
-**A multilingual repository of Biblical Names**  
-Useful for named entity recognition and other NLP tasks involving Biblical names.
-
 ### [bible-graph 🔗](https://github.com/BibleNLP/bible-graph)
 
 **Open Graph database schema for Bible data**  

--- a/content/homepage/repositories.md
+++ b/content/homepage/repositories.md
@@ -1,12 +1,10 @@
 ---
-title: "Some of our Repositories"
+title: "Repositories and Resources"
 header_menu_title: "Repositories"
 navigation_menu_title: "Repositories"
 weight: 2
 header_menu: true
 ---
-
-## Repositories and Resources
 
 ### [greek-room 🔗](https://github.com/BibleNLP/greek-room)
 


### PR DESCRIPTION
This PR:

- Moves header (so we don't have the double header)
- Removes the private repo from the list